### PR TITLE
Close voice menu after repeated `voice_menu` ccmd

### DIFF
--- a/code/UI/HUD/Voice/VoiceMenu.cs
+++ b/code/UI/HUD/Voice/VoiceMenu.cs
@@ -66,6 +66,7 @@ public partial class VoiceMenu : Panel
 	};
 
 	Panel PageContainer { get; set; }
+	Panel InfoContainer { get; set; }
 	bool Shown;
 	int ActivePage;
 	public float? AutoDismissTime;
@@ -133,6 +134,7 @@ public partial class VoiceMenu : Panel
 
 	public void Show( int menu = 0 )
 	{
+		InfoContainer.SetClass("visible", Input.GetButtonOrigin(InputButton.View) != null);
 		Shown = true;
 		AddClass( "visible" );
 		SwitchToPage( menu );

--- a/code/UI/HUD/Voice/VoiceMenu.cs
+++ b/code/UI/HUD/Voice/VoiceMenu.cs
@@ -138,6 +138,15 @@ public partial class VoiceMenu : Panel
 		SwitchToPage( menu );
 	}
 
+	public void Toggle(int menu = 0)
+	{
+		// If we're trying to open the currently active page...
+		if (Shown && ActivePage == menu)
+			Close(); // just close the menu.
+		else
+			Show(menu);
+	}
+	
 	public void NextPage()
 	{
 		if ( !Shown )
@@ -215,6 +224,6 @@ public partial class VoiceMenu : Panel
 	[ConCmd.Client( "voice_menu" )]
 	public static void Command_VoiceMenu( int menu )
 	{
-		Current?.Show( menu );
+		Current?.Toggle( menu );
 	}
 }

--- a/code/UI/HUD/Voice/VoiceMenu.html
+++ b/code/UI/HUD/Voice/VoiceMenu.html
@@ -3,15 +3,17 @@
 <root>
     <div class="container">
         <div class="menus" @ref="PageContainer" />
-        <div class="footer">
-            <InputGlyph Button="View" />
-            <text>Next Page</text>
-        </div>
-        <div class="hint">
-            <text>Don't like hitting one key to switch between menus?</text>
-            <div>
-                <InputGlyph Button="Score" />
-                <text>Learn how to bind ZXC</text>
+        <div class="info" @ref="InfoContainer">
+            <div class="footer">
+                <InputGlyph Button="View" />
+                <text>Next Page</text>
+            </div>
+            <div class="hint">
+                <text>Don't like hitting one key to switch between menus?</text>
+                <div>
+                    <InputGlyph Button="Score" />
+                    <text>Learn how to bind ZXC</text>
+                </div>
             </div>
         </div>
     </div>

--- a/code/UI/HUD/Voice/VoiceMenu.scss
+++ b/code/UI/HUD/Voice/VoiceMenu.scss
@@ -27,6 +27,15 @@ VoiceMenu {
             flex-direction: column;
         }
 
+        .info {
+            display: none;
+            flex-direction: column;
+  
+            &.visible {
+                display: flex;
+            }
+        }
+      
         .footer {
             margin-top: 10px;
             align-items: center;


### PR DESCRIPTION
Completes feature request #21
Not sure about the `Toggle` naming though.

<!-- =============== READ ME BEFORE DOING ANYTHING ELSE =============== -->
<!-- PRs must have any revelant issues or discussions linked -->
<!-- PRs must first be merged against the dev branch unless otherwise specified by the developers -->
<!-- PRs that do not follow our PR Guidelines will not be accepted -->

# Changes

If you have a voice_menu bind then:
- pressing it with a different page open will switch back to the page used in the command
- pressing it with the same page open will close the voice menu
