### PR TITLE
Fix ammo packs for weapons without reserve ammo

### DIFF
--- a/code/Entities/Pickups/AmmoPack.cs
+++ b/code/Entities/Pickups/AmmoPack.cs
@@ -28,17 +28,23 @@ public abstract class AmmoPack : PickupItem
 			if ( !weapon.Data.TryGetOwnerDataForPlayerClass( player.PlayerClass, out var ownerData ) )
 				continue;
 
-			var maxAmmo = ownerData.Reserve;
-			var ammo = weapon.Reserve;
-
 			//
 			// Restocking ammo
 			//
 
-			if ( maxAmmo > 0 )
+			if ( ownerData.Reserve > 0 )
+			{
+				weapon.Reserve = CalculateAmmo( weapon.Reserve, ownerData.Reserve );
+			}
+			else
+			{
+				weapon.Clip = CalculateAmmo( weapon.Clip, weapon.Data.ClipSize );
+			}
+
+			int CalculateAmmo(int currentAmmo, int maxAmmo)
 			{
 				// this is how much we need to fully restock our ammo
-				var need = maxAmmo - ammo;
+				var need = maxAmmo - currentAmmo;
 
 				// this is how much we can give
 				var canGive = maxAmmo * AmmoMultiplier;
@@ -48,9 +54,11 @@ public abstract class AmmoPack : PickupItem
 
 				if ( willGive > 0 )
 				{
-					weapon.Reserve += willGive;
+					currentAmmo += willGive;
 					neededAmmo = true;
 				}
+
+				return currentAmmo;
 			}
 		}
 


### PR DESCRIPTION
Fix for #16. Flamethrower and minigun were not able to replenish their ammo because they don't have a reserve ammo slot. Now, ammo is added directly to their clip slot. 


https://user-images.githubusercontent.com/84805593/203622271-546d5686-1ee5-49c7-b059-7b76a5cb25aa.mp4

