### PR TITLE
Make stickybomb launcher charging sound stop after death

### DIFF
--- a/code/Player/Weapons/StickyBombLauncher.cs
+++ b/code/Player/Weapons/StickyBombLauncher.cs
@@ -164,6 +164,7 @@ public partial class StickyBombLauncher : TFWeaponBase, IChargeable, IPassiveChi
 		SendViewModelAnimParameter( "b_charging" );
 	}
 
+	[ClientRpc]
 	public void OnStopCharge()
 	{
 		ChargeUpSound.Stop();

--- a/code/Player/Weapons/StickyBombLauncher.cs
+++ b/code/Player/Weapons/StickyBombLauncher.cs
@@ -160,6 +160,9 @@ public partial class StickyBombLauncher : TFWeaponBase, IChargeable, IPassiveChi
 
 	public void OnStartCharge()
 	{
+		if ( !Game.IsClient )
+			return;
+
 		ChargeUpSound = PlaySound( "weapon_stickybomblauncher.chargeup" );
 		SendViewModelAnimParameter( "b_charging" );
 	}


### PR DESCRIPTION
Fixes #22 
The sound didn't stop because OnStopCharge was called only on the server after death. If I remember correctly, charging sound shouldn't be heard by the other players, so I made it client-only anyway.