### PR TITLE
Fix minigun not playing firing sound to other players

### DIFF
--- a/code/Player/Weapons/Minigun.cs
+++ b/code/Player/Weapons/Minigun.cs
@@ -11,6 +11,14 @@ public partial class Minigun : TFHoldWeaponBase
 	public const float SpinnedMaxSpeed = 110;
 
 	[Net, Predicted] public float NextSpinChangeTime { get; set; }
+	[Net, Predicted] private bool IsFiring { get; set; }
+
+	public override void SimulateAttack()
+	{
+		base.SimulateAttack();
+
+		IsFiring = WishPrimaryAttack();
+	}
 
 	public override bool WishHold()
 	{
@@ -149,7 +157,7 @@ public partial class Minigun : TFHoldWeaponBase
 
 		if ( IsHolding )
 		{
-			if ( WishPrimaryAttack() )
+			if ( IsFiring )
 			{
 				if ( HasEnoughAmmoToAttack() )
 				{


### PR DESCRIPTION
<!-- =============== READ ME BEFORE DOING ANYTHING ELSE =============== -->
<!-- PRs must have any revelant issues or discussions linked -->
<!-- PRs must first be merged against the dev branch unless otherwise specified by the developers -->
<!-- PRs that do not follow our PR Guidelines will not be accepted -->

# Changes

- Fix https://github.com/AmperSoftware/TF-Source-2/issues/12

https://user-images.githubusercontent.com/91832803/223212669-ac143234-8efc-4793-8d20-e56ac5e46c4e.mp4

Long story short, the code responsible for playing the sound is run on each client's end. 
This meant that for the sound to play other clients needed to be holding the attack button as seen in the video below

https://user-images.githubusercontent.com/91832803/223213947-61d6145a-df24-48ce-8638-3211d845420e.mp4


