### PR TITLE
PR for Issue: Installation guide out of date #92

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This part aims to guide developers with installing and setting up the addon for 
 - Navigate to your s&box installation directory. For example, on Windows this would be the ``Steam/steamapps/common/sbox/`` folder.
 - Go into the ``addons`` folder and clone the repository.
 - Initialize submodules. We use our [s&box FPS SDK](https://github.com/AmperSoftware/sbox-FPS-SDK) as the core of the gamemode. If you have cloned the repository using a GUI client such as GitHub Desktop the submodule should have been initialized automatically. If not, navigate to the repository folder and run: ``git submodule update --init --recursive``. You can then navigate to the ``code/Libraries/FPS`` folder and verify that it contains content.
-- Run the developer version of s&box (sbox-dev.exe). Once loaded, add the addon using the Addon Manager widget (Add -> Add From Disk) by selecting the ``.addon`` file and verify that it is active and enabled by hovering over the checkmark icon.
+- Run the developer version of s&box (sbox-dev.exe). Once loaded, add the addon using the Project context menu, near the top (Project -> Add Existing From Disk) by selecting the ``.addon`` file and verify that it is active and enabled by hovering over the checkmark icon.
 
 Congrats! Your local version of TFS2 is ready to be played and modified.  
 If you encounter any issues during installation or the overall setup process you can contact us on our [Discord](https://discord.gg/tMnTsUsVjP).


### PR DESCRIPTION
This PR changes the 'Installing' guide in the README to align with sbox-dev.exe changes. 
Addressing issue : Installation guide out of date #92 [link](https://github.com/AmperSoftware/TF-Source-2/issues/92)

I understand this a "low-effort" change, but It could potentially be a blocker for incoming dev's trying to get in, so I thought I'd raise some attention to this issue, if it is one ! 

<!-- =============== READ ME BEFORE DOING ANYTHING ELSE =============== -->
<!-- PRs must have any revelant issues or discussions linked -->
<!-- PRs must first be merged against the dev branch unless otherwise specified by the developers -->
<!-- PRs that do not follow our PR Guidelines will not be accepted -->

