### PR TITLE
[ES] Spanish localization files

### DIFF
--- a/.localization/es/TFS2.json
+++ b/.localization/es/TFS2.json
@@ -1,0 +1,26 @@
+{
+  "GameSettings.GeneralSettings": "Ajustes",
+  "GameSettings.Reset": "Reiniciar ajustes",
+  "GameSettings.Close": "Cerrar",
+
+  "GameSettings.Social.Group": "Social",
+  "GameSettings.Combat.Group": "Combate",
+  "GameSettings.Class.Group": "Específico de clases",
+  "GameSettings.Sound.Group": "Sonido",
+  "GameSettings.Other.Group": "Otros",
+
+  "GameSettings.ShowTextChat": "Mostrar el chat de juego",
+
+  "GameSettings.ViewmodelFov": "Campo de visión del modelo del arma",
+  "GameSettings.AutoReload": "Autorrecargar cuando no estés disparando",
+  "GameSettings.FastWeaponSwitch": "Cambio rápido del arma",
+
+  "GameSettings.PlayHitSound": "Reproduce un sonido cada vez que haces daño a un enemigo",
+  "GameSettings.PlayLastHitSound": "Reproduce un último sonido al matar a un enemigo",
+  "GameSettings.HitSoundVolume": "Volumen del hitsound",
+  "GameSettings.LastHitSoundVolume": "Volumen del killsound",
+  "GameSettings.GameplayVolume": "Volumen del juego",
+
+  "GameSettings.MedigunAutoHeal": "Medic: La pistola médica sigue curando aunque dejes de pulsar el botón",
+  "GameSettings.AutoZoomIn": "Sniper: El rifle de francotirador volverá a hacer zoom despúes de disparar con el zoom activado"
+}


### PR DESCRIPTION
# Notes
Left "Hitsound" and "killsound" unchanged since I don't know if these are descriptions of a button or a button tag. Also "hitsound" and "killsound" doesn't exist in spanish and would be translated like "sonido de impacto" and "sonido de baja/asesinato" respectively, but doesn't sound quite right in spanish. Also happens wiith class-specciffic, but sound a bit better than the hiitsound.

# Changes

- Added localization files
