### PR TITLE
Remove stickies bounce after deflection in the air

### DIFF
--- a/code/Player/Weapons/Projectiles/StickyBomb.cs
+++ b/code/Player/Weapons/Projectiles/StickyBomb.cs
@@ -61,9 +61,10 @@ public partial class StickyBomb : TFProjectile
 			var vecDir = WorldSpaceBounds.Center - who.WorldSpaceBounds.Center;
 			vecDir = vecDir.Normal;
 			PhysicsBody.Velocity = vecDir * DeflectionForce;
+
+			NextRestickTime = Time.Now + tf_grenade_force_sleeptime;
 		}
 
-		NextRestickTime = Time.Now + tf_grenade_force_sleeptime;
 		NextDeflectResetTime = Time.Now + tf_pipebomb_deflect_reset_time;
 
 		base.Deflected( weapon, who );


### PR DESCRIPTION
They didn't immediately adhere to surfaces after being reflected in the air, which was wrong.