### PR TITLE
Team swapping on round restart

### DIFF
--- a/code/GameRules/Gamemodes/GamemodeEntity.cs
+++ b/code/GameRules/Gamemodes/GamemodeEntity.cs
@@ -33,5 +33,8 @@ public abstract partial class GamemodeEntity : Entity, IGamemode
 	public virtual void RoundEnd( RoundEndEvent args ) { }
 	public virtual void RoundActivate( RoundActiveEvent args ) { }
 	public virtual void RoundRestart( RoundRestartEvent args ) { Reset(); }
-
+    public virtual bool ShouldSwapTeams(int winner, int winReason)
+    {
+		return Properties.SwapTeamsOnRoundRestart;
+    }
 }

--- a/code/GameRules/Gamemodes/GamemodeEntity.cs
+++ b/code/GameRules/Gamemodes/GamemodeEntity.cs
@@ -33,7 +33,7 @@ public abstract partial class GamemodeEntity : Entity, IGamemode
 	public virtual void RoundEnd( RoundEndEvent args ) { }
 	public virtual void RoundActivate( RoundActiveEvent args ) { }
 	public virtual void RoundRestart( RoundRestartEvent args ) { Reset(); }
-    public virtual bool ShouldSwapTeams(int winner, int winReason)
+    public virtual bool ShouldSwapTeams(TFTeam winner, TFWinReason winReason)
     {
 		return Properties.SwapTeamsOnRoundRestart;
     }

--- a/code/GameRules/Gamemodes/GamemodeNetworkable.cs
+++ b/code/GameRules/Gamemodes/GamemodeNetworkable.cs
@@ -13,7 +13,7 @@ namespace TFS2
 
 		public abstract bool IsActive();
 
-		public virtual bool ShouldSwapTeams(int winner, int winReason)
+		public virtual bool ShouldSwapTeams(TFTeam winner, TFWinReason winReason)
 		{
 			return Properties.SwapTeamsOnRoundRestart;
 		}

--- a/code/GameRules/Gamemodes/GamemodeNetworkable.cs
+++ b/code/GameRules/Gamemodes/GamemodeNetworkable.cs
@@ -9,8 +9,13 @@ namespace TFS2
 
 		public virtual GamemodeProperties Properties => default;
 
-		public abstract bool HasWon( out TFTeam team, out TFWinReason reason );
+		public abstract bool HasWon(out TFTeam team, out TFWinReason reason);
 
 		public abstract bool IsActive();
+
+		public virtual bool ShouldSwapTeams(int winner, int winReason)
+		{
+			return Properties.SwapTeamsOnRoundRestart;
+		}
 	}
 }

--- a/code/GameRules/Gamemodes/GamemodeProperties.cs
+++ b/code/GameRules/Gamemodes/GamemodeProperties.cs
@@ -17,7 +17,8 @@ namespace TFS2
 		/// If false, shows the arena selection screen.
 		/// </summary>
 		public bool DisableTeamSelection { get; init; }
-		public Func<TFPlayer, TFTeam> AutoTeamOverride;
+        public bool SwapTeamsOnRoundRestart { get; init; }
+        public Func<TFPlayer, TFTeam> AutoTeamOverride;
 		public GamemodeProperties()
 		{
 			DisablePlayerRespawn = false;
@@ -27,6 +28,7 @@ namespace TFS2
 			IsAttackDefense = false;
 			RequireReadyUp = false;
 			DisableTeamSelection = false;
-		}
+			SwapTeamsOnRoundRestart = true;
+        }
 	}
 }

--- a/code/GameRules/Gamemodes/IGamemode.cs
+++ b/code/GameRules/Gamemodes/IGamemode.cs
@@ -12,5 +12,6 @@
 		public GamemodeProperties Properties { get; }
 		public bool IsActive();
 		public bool HasWon( out TFTeam team, out TFWinReason reason );
+		public bool ShouldSwapTeams(int winner, int winReason);
 	}
 }

--- a/code/GameRules/Gamemodes/IGamemode.cs
+++ b/code/GameRules/Gamemodes/IGamemode.cs
@@ -12,6 +12,6 @@
 		public GamemodeProperties Properties { get; }
 		public bool IsActive();
 		public bool HasWon( out TFTeam team, out TFWinReason reason );
-		public bool ShouldSwapTeams(int winner, int winReason);
+		public bool ShouldSwapTeams(TFTeam winner, TFWinReason winReason);
 	}
 }

--- a/code/GameRules/Gamemodes/Payload.cs
+++ b/code/GameRules/Gamemodes/Payload.cs
@@ -11,5 +11,5 @@ namespace TFS2
 	{
 		public override string Title => "Payload";
 		public override bool IsActive() => Entity.All.OfType<Cart>().Any();
-	}
+    }
 }

--- a/code/GameRules/Objectives.cs
+++ b/code/GameRules/Objectives.cs
@@ -54,11 +54,20 @@ partial class TFGameRules
 		}
 
 		//Swap player teams if this is round end, we have a winner + the gamemode allows it
-        if (IsRoundEnded && Winner != 0 && GetGamemode().ShouldSwapTeams(Winner, WinReason))
-        {
-            Log.Info("Will swap player teams");
-            SwapAllPlayersTeam();
+		try
+		{
+            if (IsRoundEnded && Winner != 0 && GetGamemode().ShouldSwapTeams((TFTeam)Winner, (TFWinReason)WinReason))
+            {
+#if DEBUG
+				Log.Info("Will swap player teams");
+#endif
+				SwapAllPlayersTeam();
+            }
         }
+        catch(InvalidCastException e)
+		{
+			Log.Error($"Failed to swap teams due to cast error: {e.Message}");
+		}
     }
 
     public override void CalculateObjectives()

--- a/code/GameRules/Objectives.cs
+++ b/code/GameRules/Objectives.cs
@@ -52,9 +52,16 @@ partial class TFGameRules
 				door.FireInput("SetPosition", door, door.InitialPosition / 100.0f );
 			}
 		}
-	}
 
-	public override void CalculateObjectives()
+		//Swap player teams if this is round end, we have a winner + the gamemode allows it
+        if (IsRoundEnded && Winner != 0 && GetGamemode().ShouldSwapTeams(Winner, WinReason))
+        {
+            Log.Info("Will swap player teams");
+            SwapAllPlayersTeam();
+        }
+    }
+
+    public override void CalculateObjectives()
 	{
 		// This function helps define what game type are we currently playing.
 

--- a/code/GameRules/Teams.cs
+++ b/code/GameRules/Teams.cs
@@ -37,6 +37,22 @@ partial class TFGameRules
 	{
 		PlaySoundToTeam( (TFTeam)team, "announcer.your_team.lost", SoundBroadcastChannel.Announcer );
 	}
+
+	/// <summary>
+	/// Swap players on Red or Blue to opposite team
+	/// </summary>
+    protected void SwapAllPlayersTeam()
+    {
+        var players = All.OfType<TFPlayer>().ToList();
+        foreach (var player in players)
+        {
+			TFTeam current = player.Team;
+            if(current == TFTeam.Red || current == TFTeam.Blue)
+			{
+				player.TeamNumber = current == TFTeam.Red ? (int)TFTeam.Blue : (int)TFTeam.Red;
+            }
+        }
+    }
 }
 
 public enum TFTeam 

--- a/code/Libraries/FPS/GameRules/Game.Round.cs
+++ b/code/Libraries/FPS/GameRules/Game.Round.cs
@@ -37,7 +37,6 @@ partial class SDKGame
 	}
 
 	public virtual void OnRoundRestart() { }
-
 	public virtual void CalculateObjectives() { }
 	public virtual void ResetObjectives() { }
 


### PR DESCRIPTION
Adds the ability for teams to be swapped on a round restart. Currently this check is restricted to a valid winner + round end state.
Can be controlled by the current game mode. Fixes #137