### PR TITLE
Fix demoman dryfiring after charging SB Launcher and switching weapons

### DIFF
--- a/code/Player/Weapons/Interfaces/IChargeable.cs
+++ b/code/Player/Weapons/Interfaces/IChargeable.cs
@@ -18,10 +18,10 @@ public interface IChargeable
 
 	public virtual bool IsCharged => IsCharging && GetCurrentCharge() >= 1;
 
-	public virtual void StopCharging()
+	public virtual void StopCharging( bool shouldFire = false )
 	{
 		IsCharging = false;
-		OnStopCharge();
+		OnStopCharge( shouldFire );
 	}
 
 	public virtual void StartCharging()
@@ -33,5 +33,5 @@ public interface IChargeable
 	}
 
 	public void OnStartCharge();
-	public void OnStopCharge();
+	public void OnStopCharge( bool shouldFire );
 }

--- a/code/Player/Weapons/StickyBombLauncher.cs
+++ b/code/Player/Weapons/StickyBombLauncher.cs
@@ -168,10 +168,12 @@ public partial class StickyBombLauncher : TFWeaponBase, IChargeable, IPassiveChi
 	}
 
 	[ClientRpc]
-	public void OnStopCharge()
+	public void OnStopCharge( bool shouldFire )
 	{
 		ChargeUpSound.Stop();
-		SendViewModelAnimParameter( "b_fire" );
+
+		SendViewModelAnimParameter( "b_charging", false );
+		if ( shouldFire ) SendViewModelAnimParameter( "b_fire" );
 	}
 
 	public override bool CanReload()
@@ -204,14 +206,14 @@ public partial class StickyBombLauncher : TFWeaponBase, IChargeable, IPassiveChi
 		{
 			PrimaryAttack();
 			CalculateNextAttackTime();
-			charger.StopCharging();
+			charger.StopCharging( true );
 		}
 	}
 
 	public override void OnHolster( SDKPlayer owner )
 	{
-		base.OnHolster( owner );
 		((IChargeable)this).StopCharging();
+		base.OnHolster( owner );
 	}
 
 	public override void OnDrop( SDKPlayer owner )


### PR DESCRIPTION
fixes #130 

Weapon logic was sending "b_fire" parameter regardless of how it was called, occasionally carrying over to the next weapon if swapping while charging, this failsafe should prevent that from happening

# Changes

- Implement bool for whether or not the call to stop charging was one made to fire the weapon
- Added call to stop charging animation parameter in future cases where we want to stop charging without switching the weapon or triggering another animation
- Move StopCharging() call in OnHolster() to BEFORE base method is called, to prevent it applying to the next weapon