### PR TITLE
Update damage numbers to remove text shadow and use correct font

### DIFF
--- a/code/UI/HUD/DamageNumbers.scss
+++ b/code/UI/HUD/DamageNumbers.scss
@@ -12,9 +12,8 @@ DamageNumbers {
         display: flex;
         position: absolute;
         color: $white;
-        font-family: TF2_Build;
+        font-family: TF2_Secondary;
         font-size: 38px;
         color: red;
-        text-shadow: 2px 2px 2px 2px black;
     }
 }


### PR DESCRIPTION
# Changes

This updates DamageNumber.scss to edit the style of the damage numbers:
- Removed text shadow
- Changed font from TF2_Build to TF2_Secondary
This better matches the look in TF2.