### PR TITLE
Fix IsLaunched and IsBlastJumping conditions not being set

### DIFF
--- a/code/Player/Damage.cs
+++ b/code/Player/Damage.cs
@@ -86,7 +86,6 @@ partial class TFPlayer
 		direction = direction.Normal;
 
 		Vector3 dmgForce = default;
-		bool wasInAir = IsInAir;
 		bool isSelfDamage = info.Attacker == this;
 		if ( info.Force == default )
 		{
@@ -122,11 +121,9 @@ partial class TFPlayer
 			dmgForce = info.Force;
 
 		ApplyAbsoluteImpulse( dmgForce );
-		if(IsInAir && !wasInAir)
-		{
-			IsLaunched= true;
-			IsBlastJumping = isSelfDamage;
-		}
+
+		IsLaunched = true;
+		IsBlastJumping = isSelfDamage;
 	}
 
 	public override void OnTakeDamageEffects( Entity attacker, Entity weapon, float damage, string[] tags, Vector3 position, Vector3 force )


### PR DESCRIPTION
<!-- =============== READ ME BEFORE DOING ANYTHING ELSE =============== -->
<!-- PRs must have any revelant issues or discussions linked -->
<!-- PRs must first be merged against the dev branch unless otherwise specified by the developers -->
<!-- PRs that do not follow our PR Guidelines will not be accepted -->

# Changes

- Removed check for if you were in the air and not in the air at the same time. This caused the conditions to never be set.

https://github.com/AmperSoftware/TF-Source-2/assets/91832803/d8fe9a5d-b616-4bda-a54d-7714a0e3a7f5


