### PR TITLE
disable uber + drain when medigun is not active

### DIFF
--- a/code/Player/Ubercharge.cs
+++ b/code/Player/Ubercharge.cs
@@ -23,8 +23,13 @@ partial class TFPlayer
 		var medigun = GetWeaponOfType<Medigun>();
 		if ( medigun.IsValid() && medigun.IsReleasingCharge )
 		{
-			var effect = medigun.GetChargeType();
-			newProvidedEffects[effect] = medigun;
+			if ( medigun == ActiveWeapon )
+			{
+				var effect = medigun.GetChargeType();
+				newProvidedEffects[effect] = medigun;
+			}
+
+			medigun.DrainCharge();
 		}
 
 		// Checking what effects healers provide right now.

--- a/code/Player/Weapons/Medigun.Charge.cs
+++ b/code/Player/Weapons/Medigun.Charge.cs
@@ -60,7 +60,8 @@ public partial class Medigun
 
 	public void SimulateCharge()
 	{
-		DrainCharge();
+		//Moved to Player UberCharge code so it ticks while weapon isn't active;
+		//DrainCharge();
 	}
 
 	public void BuildCharge()


### PR DESCRIPTION
Fixes #125
# Changes

- Ubercharge logic now also checks for a Medigun as the Active Weapon before checking if we should be self-ubered each tick
- Moved DrainCharge() call from Medigun to Ubercharge logic, allowing charge to drain even when medigun is holstered
