### PR TITLE
Fixed issue where the special kill icons do not appear and the issue when blowing yourself up displays your name twice.

### DIFF
--- a/code/Player/Weapons/Knife.cs
+++ b/code/Player/Weapons/Knife.cs
@@ -91,7 +91,10 @@ public partial class Knife : TFMeleeBase
 	public override void ApplyDamageModifications( Entity victim, ref ExtendedDamageInfo info, TraceResult trace )
 	{
 		if ( IsBackstab && victim == BackstabVictim )
+		{
 			info.Damage = victim.Health;
+			info = info.WithTag( TFDamageTags.Critical );
+		}
 
 		base.ApplyDamageModifications( victim, ref info, trace );
 	}

--- a/code/UI/HUD/Killfeed/TFKillfeedEntry.cs
+++ b/code/UI/HUD/Killfeed/TFKillfeedEntry.cs
@@ -89,7 +89,19 @@ partial class TFKillFeedEntry : Panel
 			Tags.Contains( TFDamageTags.Critical );
 			Tags.Contains( TFDamageTags.MiniCritical );
 		}
-		
+
+		//Checking if the attack was a critical hit.
+		if( Tags.Contains( TFDamageTags.Critical ) ) 
+		{
+			is_crit = true;
+		}
+
+		//Checking if the attack was a mini-critical hit.
+		if ( Tags.Contains( TFDamageTags.MiniCritical ) )
+		{
+			is_mini_crit = true;
+		}
+
 		var killIcon = Icon;
 
 		// Local Player Involved?
@@ -118,6 +130,9 @@ partial class TFKillFeedEntry : Panel
 		else if ( Victim == Attacker && Weapon == null )
 			// attacker has dealt damage to themselves with no weapon, they must have suicided.
 			PostVictimMessage.Text = " bid farewell, cruel world";
+		else if ( Victim == Attacker )
+			// Attacker blew himself up or etc.
+			AttackerName = null;
 		else if ( Attacker.IsValid() )
 		{
 			// someone else killed us.


### PR DESCRIPTION
<!-- =============== READ ME BEFORE DOING ANYTHING ELSE =============== -->
<!-- PRs must have any revelant issues or discussions linked -->
<!-- PRs must first be merged against the dev branch unless otherwise specified by the developers -->
<!-- PRs that do not follow our PR Guidelines will not be accepted -->

# Changes

- Added two separate functions in TFKillfeedEntry.cs just to check if the attack was a critical hit or mini-critical hit.
   **This fixed the issue where the special kill icons do not appear.**

- Added an else-if statement at the Attacker section in TFKillfeedEntry.cs to check if the attacker was the victim and if there was a weapon which makes the AttackerName null.
   **This fixed the issue when blowing yourself up displays your name twice.**

- Added critical hit tag to the part if there was a backstab and the victim is the BackstabVictim (which has brackets now) in the Knife.cs.
     **In TF2 whenever you backstab a victim, it will always be a critical hit.**
