### PR TITLE
Add ammo pack on player death

### DIFF
--- a/.addon
+++ b/.addon
@@ -79,7 +79,7 @@
         {
           "a": "debris",
           "b": "interactable",
-          "r": "Collide"
+          "r": "Ignore"
         },
         {
           "a": "player",
@@ -163,7 +163,7 @@
         {
           "a": "interactable",
           "b": "interactable",
-          "r": "Collide"
+          "r": "Ignore"
         },
         {
           "a": "projectile",

--- a/code/Entities/Pickups/AmmoPack.cs
+++ b/code/Entities/Pickups/AmmoPack.cs
@@ -1,14 +1,15 @@
 using Sandbox;
 using Editor;
 using System;
-using System.ComponentModel;
-using System.ComponentModel.DataAnnotations;
 using System.Linq;
+using Amper.FPS;
 
 namespace TFS2;
 
-public abstract class AmmoPack : PickupItem
+public abstract class AmmoPack : PickupItem, IAcceptsExtendedDamageInfo
 {
+	private const int BlastScale = 41;
+
 	public virtual float AmmoMultiplier => 1f;
 
 	public override void OnPicked( TFPlayer player )
@@ -75,6 +76,17 @@ public abstract class AmmoPack : PickupItem
 
 		Sound.FromEntity( "player.pickupammo", this );
 		base.OnPicked( player );
+	}
+
+	public void TakeDamage( ExtendedDamageInfo info )
+	{
+		if ( PhysicsBody.BodyType != PhysicsBodyType.Dynamic || !info.HasTag( TFDamageTags.Blast ) )
+			return;
+
+		var vec = (info.HitPosition - info.Inflictor.WorldSpaceBounds.Center).Normal;
+		vec *= info.Damage * BlastScale;
+
+		ApplyAbsoluteImpulse( vec );
 	}
 }
 

--- a/code/Player/TFPlayer.cs
+++ b/code/Player/TFPlayer.cs
@@ -199,17 +199,17 @@ public partial class TFPlayer : SDKPlayer
 		DropPickedItem();
 		CreateDeathEntities( LastDamageInfo );
 
+		var dropforce = Vector3.Random;
+		dropforce.z = 0.8f;
+		dropforce *= tf_dropped_weapons_force;
+
 		//
 		// Drop active weapon
 		//
 
 		if ( ActiveWeapon.IsValid() )
 		{
-			var force = Vector3.Random;
-			force.z = 0.8f;
-			force *= tf_dropped_weapons_force;
-
-			if(ActiveWeapon is Builder b && b.IsCarryingBuilding)
+			if ( ActiveWeapon is Builder b && b.IsCarryingBuilding )
 			{
 				var building = b.CarriedBuilding;
 				building.TakeDamage( LastDamageInfo );
@@ -218,8 +218,10 @@ public partial class TFPlayer : SDKPlayer
 			}
 
 			ActiveWeapon.OnHolster( this );
-			DropWeapon( ActiveWeapon, WorldSpaceBounds.Center, force );
+			DropWeapon( ActiveWeapon, WorldSpaceBounds.Center, dropforce );
 		}
+
+		DropAmmoPack( dropforce );
 
 		if ( InCondition( TFCondition.Taunting ) )
 		{
@@ -431,5 +433,21 @@ public partial class TFPlayer : SDKPlayer
 
 		// Apply spy touched effects.
 		player.OnSpyTouchedWhileCloaked();
+	}
+
+	private void DropAmmoPack( Vector3 force )
+	{
+		var pack = new AmmoPackMedium
+		{
+			Respawns = false,
+			PlaybackRate = 0
+		};
+
+		pack.Position = WorldSpaceBounds.Center;
+		pack.SetupPhysicsFromModel( PhysicsMotionType.Dynamic );
+
+		var velocity = force + Velocity;
+		pack.Rotation = Rotation.LookAt( velocity );
+		pack.ApplyAbsoluteImpulse( velocity );
 	}
 }


### PR DESCRIPTION
I had to change the collision rules so that packs and ragdolls don't collide with each other.

https://github.com/AmperSoftware/TF-Source-2/assets/84805593/96d4d37d-1ffe-4bec-8bd8-392e82befc80

