### PR TITLE
Add UI for +Health on health kit pickup + minor fixes

### DIFF
--- a/code/Entities/Pickups/AmmoPack.cs
+++ b/code/Entities/Pickups/AmmoPack.cs
@@ -17,7 +17,7 @@ public abstract class AmmoPack : PickupItem, IAcceptsExtendedDamageInfo
 		if ( !player.GiveAmmo( AmmoMultiplier ) ) 
 			return;
 
-		Sound.FromEntity( "player.pickupammo", this );
+		Sound.FromEntity( To.Single( player ), "player.pickupammo", player );
 		base.OnPicked( player );
 	}
 

--- a/code/Entities/Pickups/HealthKit.cs
+++ b/code/Entities/Pickups/HealthKit.cs
@@ -15,9 +15,9 @@ public abstract class HealthKit : PickupItem
 			return;
 
 		var health = player.GiveHealth( MathF.Ceiling( player.GetMaxHealth() * HealthMultiplier ) );
-		EventDispatcher.InvokeEvent( To.Single(player), new PlayerHealthKitPickUpEvent { Health = health } );
+		EventDispatcher.InvokeEvent( To.Single( player ), new PlayerHealthKitPickUpEvent { Health = health } );
 
-		Sound.FromEntity( "Player.PickupHealth", this );
+		Sound.FromEntity( To.Single( player ), "Player.PickupHealth", player );
 
 		player.RemoveCondition( TFCondition.Burning );
 

--- a/code/Entities/Pickups/HealthKit.cs
+++ b/code/Entities/Pickups/HealthKit.cs
@@ -1,7 +1,7 @@
 ﻿using Sandbox;
 using Editor;
 using System;
-using System.ComponentModel;
+using Amper.FPS;
 
 namespace TFS2;
 
@@ -14,9 +14,12 @@ public abstract class HealthKit : PickupItem
 		if ( player.Health >= player.GetMaxHealth() ) // We dont need to give health to people who are already at max
 			return;
 
-		player.GiveHealth( MathF.Ceiling( player.GetMaxHealth() * HealthMultiplier ) );
-		base.OnPicked( player );
+		var health = player.GiveHealth( MathF.Ceiling( player.GetMaxHealth() * HealthMultiplier ) );
+		EventDispatcher.InvokeEvent( To.Single(player), new PlayerHealthKitPickUpEvent { Health = health } );
+
 		Sound.FromEntity( "Player.PickupHealth", this );
+
+		base.OnPicked( player );
 	}
 
 	protected override void RespawnPickup()

--- a/code/Entities/Pickups/HealthKit.cs
+++ b/code/Entities/Pickups/HealthKit.cs
@@ -19,6 +19,8 @@ public abstract class HealthKit : PickupItem
 
 		Sound.FromEntity( "Player.PickupHealth", this );
 
+		player.RemoveCondition( TFCondition.Burning );
+
 		base.OnPicked( player );
 	}
 

--- a/code/Events.cs
+++ b/code/Events.cs
@@ -1,6 +1,5 @@
 ﻿using Sandbox;
 using Amper.FPS;
-using System.Collections.Generic;
 
 namespace TFS2;
 
@@ -58,6 +57,12 @@ public class PlayerChangeTeamEvent : DispatchableEventBase
 public class PlayerRegenerateEvent : DispatchableEventBase
 {
 	public IClient Client { get; set; }
+}
+
+[EventDispatcherEvent]
+public class PlayerHealthKitPickUpEvent : DispatchableEventBase
+{
+	public float Health { get; set; }
 }
 
 [EventDispatcherEvent]

--- a/code/Libraries/FPS/Util/EventDispatcher/EventDispatcher.cs
+++ b/code/Libraries/FPS/Util/EventDispatcher/EventDispatcher.cs
@@ -210,9 +210,19 @@ public partial class EventDispatcher
 	/// <param name="args">The event object to send</param>
 	public static void InvokeEvent( DispatchableEventBase args )
 	{
+		InvokeEvent( To.Everyone, args );
+	}
+
+	/// <summary>
+	/// Invoke this dispatchable event with the provided data for the specified clients.
+	/// </summary>
+	/// <param name="target">Event receivers</param>
+	/// <param name="args">The event object to send</param>
+	public static void InvokeEvent( To target, DispatchableEventBase args )
+	{
 		Type type = args.GetType();
 		var eventAttribute = TypeLibrary.GetAttribute<EventDispatcherEventAttribute>( type );
-		InvokeEvent( args, eventAttribute.dispatchTypes );
+		InvokeEvent( target, args, eventAttribute.dispatchTypes );
 	}
 
 	public static void InvokeEvent<T>() where T : DispatchableEventBase, new()
@@ -221,11 +231,12 @@ public partial class EventDispatcher
 	}
 
 	/// <summary>
-	/// Invoke this dispatchable event with the provided data, using the provided dispatch types.
+	/// Invoke this dispatchable event with the provided data for the specified clients, using the provided dispatch types.
 	/// </summary>
+	/// <param name="target">Event receivers</param>
 	/// <param name="args">The event object to send</param>
 	/// <param name="dispatchTypes">Dispatch types for this invokation</param>
-	public static void InvokeEvent( DispatchableEventBase args, DispatchType dispatchTypes )
+	public static void InvokeEvent( To target, DispatchableEventBase args, DispatchType dispatchTypes )
 	{
 		Type type = args.GetType();
 		string name = type.Name;
@@ -241,7 +252,7 @@ public partial class EventDispatcher
 			else
 			{
 				string data = JsonSerializer.Serialize( args, type, serializerOptions );
-				RecieveEvent( name, data);
+				RecieveEvent( target, name, data);
 			}
 		}
 

--- a/code/UI/HUD/Player/Health.scss
+++ b/code/UI/HUD/Player/Health.scss
@@ -47,4 +47,32 @@ Health {
         bottom: 1.8%;
         left: 8%;
     }
+
+    .health_update {
+        position: absolute;
+        width: 100%;
+        font-family: TF2_Secondary;
+        font-size: 50px;
+        color: $green;
+        top: -60%;
+        left: 85%;
+        z-index: 1;
+        display: flex;
+        animation-name: health-update;
+    }
+}
+
+@keyframes health-update {
+    0% {
+        opacity: 1;
+        transform: translateY(0%);
+    }
+    50% {
+        opacity: 1;
+        transform: translateY(-100%);
+    }
+    100% {
+        opacity: 0;
+        transform: translateY(-200%);
+    }
 }

--- a/code/UI/styles/colors.scss
+++ b/code/UI/styles/colors.scss
@@ -46,5 +46,6 @@ $panel-text: #F2E2C1;
 $panel-bg: #2C2B2BCC;
 
 $orange: #352417;
+$green: #00FF00;
 
 $pda-background: #3a3a3a77;


### PR DESCRIPTION
# Changes

- Add UI for +Health, resolves #134 
- Remove burning condition from players on health kit pickup
- Make picking up ammo packs and health kits only audible to the player who picked them up

https://github.com/AmperSoftware/TF-Source-2/assets/84805593/3aea8831-ec68-4f1a-9ca4-cf717409ccb5